### PR TITLE
Fix README tree formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Ci-dessous, le diagramme (Mermaid) de l’architecture générale :
 ---
 
 ## Structure du dépôt
-
+```
 ├── etl.py
 ├── train.py
 ├── evaluate.py
@@ -34,3 +34,4 @@ Ci-dessous, le diagramme (Mermaid) de l’architecture générale :
 ├── docs/
 │ └── architecture.png
 └── README.md
+```


### PR DESCRIPTION
## Summary
- wrap repo structure tree in a fenced code block so it renders properly
- ensure the file ends with a newline

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849dc2ff1fc832396e0355410539d7b